### PR TITLE
Use correct version variable to install angular lsp

### DIFF
--- a/src/angular.rs
+++ b/src/angular.rs
@@ -52,7 +52,6 @@ impl AngularExtension {
         );
 
         let version = zed::npm_package_latest_version(PACKAGE_NAME)?;
-        let ts_version = zed::npm_package_latest_version(TYPESCRIPT_PACKAGE_NAME)?;
 
         if !server_exists
             || zed::npm_package_installed_version(PACKAGE_NAME)?.as_ref() != Some(&version)
@@ -61,7 +60,7 @@ impl AngularExtension {
                 language_server_id,
                 &zed::LanguageServerInstallationStatus::Downloading,
             );
-            let result = zed::npm_install_package(PACKAGE_NAME, &ts_version);
+            let result = zed::npm_install_package(PACKAGE_NAME, &version);
             match result {
                 Ok(()) => {
                     if !self.server_exists() {


### PR DESCRIPTION
After fixing the version variable used to install the LSP package, the `ts_version` variable is not used anywhere - so I've removed that