### PR TITLE
fix: use arguments to start the server according to the official Angular extension

### DIFF
--- a/src/angular.rs
+++ b/src/angular.rs
@@ -16,7 +16,6 @@ const TYPESCRIPT_TSDK_PATH: &str = "node_modules/typescript/lib";
 const ANGULAR_SERVER_PACKAGE_NAME: &str = "@angular/language-server";
 const TYPESCRIPT_PACKAGE_NAME: &str = "typescript";
 
-
 #[derive(Deserialize, Default)]
 struct UserSettings {
     angular_language_service_version: Option<String>,
@@ -101,10 +100,18 @@ impl AngularExtension {
             ANGULAR_SERVER_PACKAGE_NAME, als_version, TYPESCRIPT_PACKAGE_NAME, ts_version
         );
 
-        zed::npm_install_package(ANGULAR_SERVER_PACKAGE_NAME, &als_version)
-            .map_err(|error| format!("Failed to install package '{}': {}", ANGULAR_SERVER_PACKAGE_NAME, error))?;
-        zed::npm_install_package(TYPESCRIPT_PACKAGE_NAME, &ts_version)
-            .map_err(|error| format!("Failed to install package '{}': {}", ANGULAR_SERVER_PACKAGE_NAME, error))?;
+        zed::npm_install_package(ANGULAR_SERVER_PACKAGE_NAME, &als_version).map_err(|error| {
+            format!(
+                "Failed to install package '{}': {}",
+                ANGULAR_SERVER_PACKAGE_NAME, error
+            )
+        })?;
+        zed::npm_install_package(TYPESCRIPT_PACKAGE_NAME, &ts_version).map_err(|error| {
+            format!(
+                "Failed to install package '{}': {}",
+                ANGULAR_SERVER_PACKAGE_NAME, error
+            )
+        })?;
 
         Ok(())
     }

--- a/src/angular.rs
+++ b/src/angular.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 use std::path::PathBuf;
-use std::{env, fs};
+use std::{env, fs, vec};
 use zed::lsp::{Completion, CompletionKind};
 use zed::settings::LspSettings;
 use zed::CodeLabelSpan;
@@ -11,12 +11,11 @@ const DEFAULT_ANGULAR_LANGUAGE_SERVICE_VERSION: &str = "18.2.0";
 const DEFAULT_TYPESCRIPT_VERSION: &str = "5.5.4";
 
 const SERVER_PATH: &str = "node_modules/@angular/language-server/index.js";
+const TYPESCRIPT_TSDK_PATH: &str = "node_modules/typescript/lib";
 
-const PACKAGE_NAME: &str = "@angular/language-server";
+const ANGULAR_SERVER_PACKAGE_NAME: &str = "@angular/language-server";
 const TYPESCRIPT_PACKAGE_NAME: &str = "typescript";
 
-const TYPESCRIPT_TSDK_PATH: &str = "node_modules/typescript/lib";
-const NG_SERVICE_PATH: &str = "node_modules/@angular/language-service";
 
 #[derive(Deserialize, Default)]
 struct UserSettings {
@@ -26,8 +25,6 @@ struct UserSettings {
 
 struct AngularExtension {
     did_find_server: bool,
-    typescript_tsdk_path: String,
-    ng_service_path: String,
     angular_language_service_version: String,
     typescript_version: String,
 }
@@ -56,7 +53,6 @@ impl AngularExtension {
     }
 
     fn server_script_path(&mut self, language_server_id: &zed::LanguageServerId) -> Result<String> {
-        self.set_ng_service_path()?;
         let server_exists = self.file_exists_at_path(&SERVER_PATH);
 
         if self.did_find_server && server_exists {
@@ -78,7 +74,7 @@ impl AngularExtension {
         if !self.file_exists_at_path(&SERVER_PATH) {
             return Err(format!(
                 "Installed package '{}' did not contain expected path '{}'",
-                PACKAGE_NAME, SERVER_PATH
+                ANGULAR_SERVER_PACKAGE_NAME, SERVER_PATH
             )
             .into());
         }
@@ -89,7 +85,7 @@ impl AngularExtension {
 
     fn install_packages(&mut self) -> Result<()> {
         let als_version = if self.angular_language_service_version == "latest" {
-            zed::npm_package_latest_version(PACKAGE_NAME)?
+            zed::npm_package_latest_version(ANGULAR_SERVER_PACKAGE_NAME)?
         } else {
             self.angular_language_service_version.clone()
         };
@@ -102,25 +98,47 @@ impl AngularExtension {
 
         println!(
             "Installing {}@{}, {}@{}",
-            PACKAGE_NAME, als_version, TYPESCRIPT_PACKAGE_NAME, ts_version
+            ANGULAR_SERVER_PACKAGE_NAME, als_version, TYPESCRIPT_PACKAGE_NAME, ts_version
         );
 
-        zed::npm_install_package(PACKAGE_NAME, &als_version)
-            .map_err(|error| format!("Failed to install package '{}': {}", PACKAGE_NAME, error))?;
+        zed::npm_install_package(ANGULAR_SERVER_PACKAGE_NAME, &als_version)
+            .map_err(|error| format!("Failed to install package '{}': {}", ANGULAR_SERVER_PACKAGE_NAME, error))?;
         zed::npm_install_package(TYPESCRIPT_PACKAGE_NAME, &ts_version)
-            .map_err(|error| format!("Failed to install package '{}': {}", PACKAGE_NAME, error))?;
+            .map_err(|error| format!("Failed to install package '{}': {}", ANGULAR_SERVER_PACKAGE_NAME, error))?;
 
         Ok(())
     }
 
-    fn set_ng_service_path(&mut self) -> Result<()> {
-        let current_dir =
-            env::current_dir().map_err(|e| format!("Failed to get current directory: {}", e))?;
-        self.ng_service_path = current_dir
-            .join("node_modules/@angular/language-service/bin")
-            .to_string_lossy()
-            .to_string();
-        Ok(())
+    fn get_current_dir() -> Result<PathBuf> {
+        env::current_dir().map_err(|e| format!("Failed to get current directory: {}", e))
+    }
+
+    fn get_ng_probe_locations(worktree: Option<&zed::Worktree>) -> Vec<String> {
+        let mut paths = vec![];
+
+        if let Ok(path) = Self::get_current_dir() {
+            paths.push(path.to_string_lossy().to_string());
+        }
+
+        if let Some(worktree) = worktree {
+            paths.push(worktree.root_path());
+        }
+
+        paths
+    }
+
+    fn get_ts_probe_locations(worktree: Option<&zed::Worktree>) -> Vec<String> {
+        let mut paths = vec![];
+
+        if let Ok(path) = Self::get_current_dir() {
+            paths.push(path.to_string_lossy().to_string());
+        }
+
+        if let Some(worktree) = worktree {
+            paths.push(worktree.root_path());
+        }
+
+        paths
     }
 }
 
@@ -128,8 +146,6 @@ impl zed::Extension for AngularExtension {
     fn new() -> Self {
         Self {
             did_find_server: false,
-            typescript_tsdk_path: TYPESCRIPT_TSDK_PATH.to_owned(),
-            ng_service_path: NG_SERVICE_PATH.to_owned(),
             angular_language_service_version: DEFAULT_ANGULAR_LANGUAGE_SERVICE_VERSION.to_owned(),
             typescript_version: DEFAULT_TYPESCRIPT_VERSION.to_owned(),
         }
@@ -154,34 +170,23 @@ impl zed::Extension for AngularExtension {
         let current_dir = env::current_dir().unwrap_or(PathBuf::new());
         let full_path_to_server = current_dir.join(&server_path);
 
-        let args = vec![
-            full_path_to_server.to_string_lossy().to_string(),
-            "--stdio".to_string(),
-            "--tsProbeLocations".to_string(),
-            self.typescript_tsdk_path.clone(),
-            "--ngProbeLocations".to_string(),
-            self.ng_service_path.clone(),
-        ];
+        let mut args = vec![full_path_to_server.to_string_lossy().to_string()];
+        args.push("--stdio".to_string());
+
+        args.push("--tsProbeLocations".to_string());
+        args.extend(Self::get_ts_probe_locations(Some(worktree)));
+
+        args.push("--ngProbeLocations".to_string());
+        args.extend(Self::get_ng_probe_locations(Some(worktree)));
+
+        args.push("--tsdk".to_string());
+        args.push(TYPESCRIPT_TSDK_PATH.to_string());
 
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args,
             env: Default::default(),
         })
-    }
-
-    fn language_server_initialization_options(
-        &mut self,
-        _language_server_id: &zed::LanguageServerId,
-        _worktree: &zed::Worktree,
-    ) -> Result<Option<serde_json::Value>> {
-        let options = serde_json::json!({
-            "typescript": {
-                "tsdk": self.typescript_tsdk_path,
-            },
-            "ngProbeLocations": self.ng_service_path,
-        });
-        Ok(Some(options))
     }
 
     fn label_for_completion(


### PR DESCRIPTION
I've slightly improved the version matching branch (#15).

I've changed the selection of the Angular and TypeScript instance to run the server command, based on how it works in the official Angular extension for VS Code: [the function responsible for composing the command](https://github.com/angular/vscode-ng-language-service/blob/6692c40500cabe7f1fae9cc12e6298946a2e37ee/client/src/client.ts#L292).

Now the ALS instance is probing first from within the extension, and then from within the user's project, just like in the official extension. TypeScript instance now also probing by this scheme.

This solves the issue with older versions of Angular (15 in my case), where in the current state there is an error about mismatched TypeScript and Angular versions, and forces the user to manually set the appropriate versions in the configuration of this plugin.

Also removed some unnecessary fields and constants.