### PR TITLE
feat: add explanation about language server in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Note: This project is currently a work in progress. Expect potential bugs or issues.**
 
-This extension integrates the Angular Language Service into Zed. It uses the same options that Angular applies during compilation. To ensure the most accurate information, enable the `strictTemplates` option in the `tsconfig.json` of the angular project  as shown in below:
+This extension integrates the Angular Language Service into Zed. It uses the same options that Angular applies during compilation. To ensure the most accurate information, enable the `strictTemplates` option in the `tsconfig.json` of the angular project as shown in below:
 
 ```json
 "angularCompilerOptions": {
@@ -31,7 +31,7 @@ The extension depends on `@angular/language-service` and `typescript` Node packa
 
 Please ensure the versions of Angular and TypeScript are compatible to avoid issues.
 
-Refer to [Angular Version Compatibility](https://angular.dev/reference/versions#unsupported-angular-versions) for details. Mismatched versions may lead to bugs, so it is not recommended to use `latest` as a version, but it's also a valid option.  
+Refer to [Angular Version Compatibility](https://angular.dev/reference/versions#unsupported-angular-versions) for details. Mismatched versions may lead to bugs, so it is not recommended to use `latest` as a version, but it's also a valid option.
 
 ## Installation Instructions
 
@@ -41,3 +41,17 @@ To install this extension locally:
 2. Open the Zed editor and navigate to the Extensions window.
 3. Click on "Install Dev Extension."
 4. Select the cloned repository location and complete the installation.
+5. Add a language server list definition to the HTML and TypeScript language settings. In `settings.json`, add the following _(ellipsis is a valid value in settings, use it as shown)_:
+
+```json
+{
+  "languages": {
+    "TypeScript": {
+      "language_servers": ["angular", "..."]
+    },
+    "HTML": {
+      "language_servers": ["angular", "..."]
+    }
+  }
+}
+```


### PR DESCRIPTION
Added a description of the necessary (for now) point to the installation instructions: explicitly setting Angular Language Server in first place for the TS and HTML languages (https://github.com/nathansbradshaw/zed-angular/issues/19#issuecomment-2629464735).