### PR TITLE
fix invalid property in config.toml

### DIFF
--- a/languages/angular/config.toml
+++ b/languages/angular/config.toml
@@ -37,8 +37,7 @@ real_time_syntax_checking = true
 real_time_semantic_checking = true
 code_lens_features = ["references", "tests"]
 
-# Documentation and tooltips
-documentation = true
+# tooltips
 hover_information = true
 
 # Plugin and extension support


### PR DESCRIPTION
@nb-midwestern @nathansbradshaw 

unsure where these properties are coming from, I see no mention of them in the zed extension documentation

but the `documentation` property is breaking the extension's ability to install or initialize on the newest version of Zed... fixes #47.

removing it for now will alleviate this.

can we merge this, increment version and publish to zed extension?