### PR TITLE
Remove invalid keys from config.toml.

### DIFF
--- a/languages/angular/config.toml
+++ b/languages/angular/config.toml
@@ -27,18 +27,3 @@ brackets = [
         "string",
     ] },
 ]
-
-# Integration with other tools
-linting = ["eslint", "codelyzer"]
-formatting = ["prettier"]
-
-# Real-time features
-real_time_syntax_checking = true
-real_time_semantic_checking = true
-code_lens_features = ["references", "tests"]
-
-# tooltips
-hover_information = true
-
-# Plugin and extension support
-plugin_support = true


### PR DESCRIPTION
Follow-up to:
- https://github.com/nathansbradshaw/zed-angular/pull/48

I believe these language config.toml are no-ops and should be removed.