### PR TITLE
Avoid a leading slash in Windows paths for Angular LSP Server

### DIFF
--- a/src/angular.rs
+++ b/src/angular.rs
@@ -119,7 +119,14 @@ impl AngularExtension {
     }
 
     fn get_current_dir() -> Result<PathBuf> {
-        env::current_dir().map_err(|e| format!("Failed to get current directory: {}", e))
+        let mut current_dir =
+            env::current_dir().map_err(|e| format!("Failed to get current directory: {}", e));
+
+        if let Ok(path) = current_dir {
+            current_dir = Ok(zed_ext::sanitize_windows_path(path));
+        }
+
+        current_dir
     }
 
     fn get_ng_probe_locations(worktree: Option<&zed::Worktree>) -> Vec<String> {
@@ -177,7 +184,7 @@ impl zed::Extension for AngularExtension {
 
         let server_path = self.server_script_path(language_server_id)?;
         let current_dir = env::current_dir().unwrap_or(PathBuf::new());
-        let full_path_to_server = current_dir.join(&server_path);
+        let full_path_to_server = zed_ext::sanitize_windows_path(current_dir).join(&server_path);
 
         let mut args = vec![full_path_to_server.to_string_lossy().to_string()];
         args.push("--stdio".to_string());
@@ -239,3 +246,25 @@ impl zed::Extension for AngularExtension {
 }
 
 zed::register_extension!(AngularExtension);
+
+/// Extensions to the Zed extension API that have not yet stabilized.
+mod zed_ext {
+    /// Sanitizes the given path to remove the leading `/` on Windows.
+    ///
+    /// On macOS and Linux this is a no-op.
+    ///
+    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
+    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        use zed_extension_api::{current_platform, Os};
+
+        let (os, _arch) = current_platform();
+        match os {
+            Os::Mac | Os::Linux => path,
+            Os::Windows => path
+                .to_string_lossy()
+                .to_string()
+                .trim_start_matches('/')
+                .into(),
+        }
+    }
+}


### PR DESCRIPTION
This PR implements changes to avoid a leading slash in Windows paths for the Angular LSP server.

- Based on https://github.com/zed-extensions/astro/pull/5 implemented by @maxdeviant
- Addresses the issue discussed at https://github.com/zed-industries/zed/issues/20559

### Credit
Big thanks to @maxdeviant for the original fix.