### PR TITLE
Improve startup time by avoiding redundant downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "zed_angular"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "serde",
  "zed_extension_api",


### PR DESCRIPTION
## Problem
Currently, the extension attempts to install/download the Angular Language Server and TypeScript packages every time the language server starts. This causes a significant delay on every startup, even if the packages are already installed and up-to-date.

## Solution
This PR updates the startup logic to:

Check the package.json of the installed @angular/language-server and typescript packages in node_modules.
Compare the installed version with the requested version (or the latest version if configured as "latest").
Skip the download/install step if the versions match and the server file exists.
This drastically reduces startup time for subsequent runs while still ensuring the extension updates when the configured version changes.