### PR TITLE
fix: Enable Tailwind CSS autocomplete in Angular template files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,16 @@ To install this extension locally:
     },
     "HTML": {
       "language_servers": ["angular", "..."]
+    },
+    "Angular": {
+      "language_servers": ["angular", "tailwindcss-language-server", "..."]
     }
   }
 }
 ```
+
+## Tailwind CSS Support
+
+This version includes a fix for Tailwind CSS autocomplete in Angular template files. The Angular language now correctly maps to HTML for language server communication, enabling Tailwind CSS IntelliSense to work in both `.component.html` files and inline templates.
+
+To enable Tailwind CSS support, add the configuration above to your `settings.json`, ensuring the Angular language includes both the `angular` and `tailwindcss-language-server` language servers.

--- a/extension.toml
+++ b/extension.toml
@@ -10,7 +10,7 @@ path_suffixes = ["html", "ng.html"]
 [language_servers.angular]
 name = "Angular Language Server"
 languages = ["TypeScript", "HTML", "Angular"]
-language_ids = { "Angular" = "angular", "HTML" = "html", "TypeScript" = "typescript" }
+language_ids = { "Angular" = "html", "HTML" = "html", "TypeScript" = "typescript" }
 command = { extension = true }
 
 [grammars.angular]

--- a/languages/angular/config.toml
+++ b/languages/angular/config.toml
@@ -5,7 +5,6 @@ block_comment = ["<!-- ", " -->"]
 autoclose_before = ";:.,=}])>\"'"
 prettier_parser_name = "angular"
 
-scope_opt_in_language_servers = ["tailwindcss-language-server"]
 
 # Define brackets for TypeScript, HTML, CSS, and SCSS with Angular specific extensions
 brackets = [


### PR DESCRIPTION
## Problem
Tailwind CSS autocomplete wasn't working in Angular `.component.html` files - it only worked in inline templates within `.ts` files.

Previously, the only workaround was to manually change the file language from "Angular" to "HTML", but this caused the loss of TypeScript variable references from the component, making the Angular IntelliSense much worse.

## Solution
This PR makes two changes that together fix the issue:

1. **Change language_id mapping** in `extension.toml`:
   - Changed `"Angular" = "angular"` to `"Angular" = "html"`
   
2. **Remove `scope_opt_in_language_servers` line** from `languages/angular/config.toml`
   - Removed: `scope_opt_in_language_servers = ["tailwindcss-language-server"]`

Both changes are needed - the language_id mapping alone doesn't solve it, and removing the scope_opt_in line alone doesn't solve it either. Together, they enable Tailwind autocomplete while keeping the file detected as "Angular" language, preserving all Angular IntelliSense features.

## Configuration Required
Users need to add this to their Zed `settings.json`:
\`\`\`json
{
  "languages": {
    "Angular": {
      "language_servers": ["angular", "tailwindcss-language-server", "..."]
    }
  }
}
\`\`\`

## Result
Now Tailwind CSS autocomplete works in `.component.html` files while keeping them as "Angular" language type, maintaining full Angular IntelliSense with TypeScript variable references.

Related to https://github.com/zed-industries/zed/issues/39507