### PR TITLE
fix: implement LSP initialization and configuration handlers

### DIFF
--- a/src/angular.rs
+++ b/src/angular.rs
@@ -198,6 +198,30 @@ impl zed::Extension for AngularExtension {
         })
     }
 
+    fn language_server_initialization_options(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let initialization_options = LspSettings::for_worktree(Self::LANGUAGE_SERVER_ID, worktree)
+            .ok()
+            .and_then(|settings| settings.initialization_options)
+            .unwrap_or_else(|| serde_json::json!({}));
+        Ok(Some(initialization_options))
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree(Self::LANGUAGE_SERVER_ID, worktree)
+            .ok()
+            .and_then(|settings| settings.settings)
+            .unwrap_or_else(|| serde_json::json!({}));
+        Ok(Some(settings))
+    }
+
     fn label_for_completion(
         &self,
         _language_server_id: &zed::LanguageServerId,


### PR DESCRIPTION
This actually a series a fixes to make that extension work again. You can try out the extension locally over at https://github.com/pmig/zed-angular. Although most of the code was written by claude, I (@pmig) manually reviewed and tested it.

## Summary
- Adds `language_server_initialization_options` trait method to forward user-configured LSP init options to the Angular Language Server
- Adds `language_server_workspace_configuration` trait method to respond to `workspace/configuration` requests from the server
- Without these, the Angular LS's `workspace/configuration` requests fail with `Error("relative URL without a base")`, and user-configured LSP settings (via Zed's `lsp` settings) are not forwarded to the server

Follows the same pattern used by the [Vue extension](https://github.com/zed-extensions/vue).

Relates to #69, #77
