### PR TITLE
fix: update default Angular LS and TypeScript versions

### DIFF
--- a/src/angular.rs
+++ b/src/angular.rs
@@ -7,8 +7,8 @@ use zed::CodeLabelSpan;
 use zed_extension_api::{self as zed, serde_json, Result};
 
 // The Latest version of typescript isn't always compatible with angular see: https://angular.dev/reference/versions#unsupported-angular-versions
-const DEFAULT_ANGULAR_LANGUAGE_SERVER_VERSION: &str = "19.0.4";
-const DEFAULT_TYPESCRIPT_VERSION: &str = "5.7.3";
+const DEFAULT_ANGULAR_LANGUAGE_SERVER_VERSION: &str = "21.1.5";
+const DEFAULT_TYPESCRIPT_VERSION: &str = "5.9.3";
 
 const SERVER_PATH: &str = "node_modules/@angular/language-server/index.js";
 const TYPESCRIPT_TSDK_PATH: &str = "node_modules/typescript/lib";


### PR DESCRIPTION
This actually a series a fixes to make that extension work again. You can try out the extension locally over at https://github.com/pmig/zed-angular. Although most of the code was written by claude, I (@pmig) manually reviewed and tested it.

## Summary
- Updates `@angular/language-server` default from **19.0.4** to **21.1.5**
- Updates `typescript` default from **5.7.3** to **5.9.3**

Angular v21 moved type declarations from `@angular/core/core.d.ts` to `@angular/core/types/core.d.ts`. The v19 language server's project detection uses `path.endsWith("@angular/core/core.d.ts")` which no longer matches, causing it to disable the language service entirely with the message: *"project is not an Angular project ('@angular/core' could not be found)"*.

The v21 language server uses a regex (`/@angular\/core\/.+\.d\.ts$/`) that correctly matches the new path structure.

This is the **root cause** of autocompletion and diagnostics not working for Angular v21+ projects.

Closes #77
Relates to #69
