### PR TITLE
Auto-detect the project's Angular version (and VSCode-parity settings)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "zed_angular"
-version = "0.0.5"
+version = "0.1.0"
 dependencies = [
  "serde",
  "zed_extension_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_angular"
-version = "0.0.5"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ This extension integrates the Angular Language Service into Zed. It uses the sam
 
 ## Version Management
 
-The extension depends on `@angular/language-service` and `typescript` Node packages. By default, these versions are managed internally, but they can be customized using the following settings:
+The extension depends on the `@angular/language-server` and `typescript` Node packages. It tries to **automatically match the Angular version of your project**, so it works out of the box from older Angular (v13) up to the latest release — no per-project configuration needed.
+
+The version is resolved in the following order of priority:
+
+1. **Manual override** — versions you set in `initialization_options` (see below) always win.
+2. **Project's own language server** — if `@angular/language-server` and `typescript` are already installed in your project's `node_modules` (including monorepos with hoisted dependencies), the extension uses them directly, guaranteeing an exact match with your project.
+3. **Derived from `package.json`** — otherwise, the extension reads the `@angular/core` (or `@angular/language-service`) version from your project's `package.json`, derives a compatible `@angular/language-server` + `typescript` pair, and installs it.
+4. **Defaults** — if nothing can be detected, it falls back to a modern default.
+
+You can still pin versions explicitly (useful for monorepos or unusual setups where auto-detection doesn't apply):
 
 ```json
 {
@@ -32,6 +41,50 @@ The extension depends on `@angular/language-service` and `typescript` Node packa
 Please ensure the versions of Angular and TypeScript are compatible to avoid issues.
 
 Refer to [Angular Version Compatibility](https://angular.dev/reference/versions#unsupported-angular-versions) for details. Mismatched versions may lead to bugs, so it is not recommended to use `latest` as a version, but it's also a valid option.
+
+> Tip: to see which versions the extension resolved, open the Angular language server logs in Zed (command palette → `dev: open language server logs`). The extension logs lines prefixed with `[angular]`.
+
+## Feature Settings
+
+The same `initialization_options` block accepts the Angular Language Service settings, using the **exact dot-namespaced keys** of the official VSCode extension — so you can copy them straight from the Angular docs. All are optional.
+
+```json
+{
+  "lsp": {
+    "angular": {
+      "initialization_options": {
+        "angular.forceStrictTemplates": true,
+        "angular.suggest.autoImports": true,
+        "angular.suggest.includeCompletionsWithSnippetText": true,
+        "angular.suggest.includeAutomaticOptionalChainCompletions": true,
+        "angular.suppressAngularDiagnosticCodes": "-992008,-998001",
+        "angular.server.useClientSideFileWatcher": false,
+
+        "angular.inlayHints.variableTypes.ifAliasTypes": true,
+        "angular.inlayHints.bindingHints.pipeOutputTypes": true,
+        "angular.inlayHints.eventHints.parameterTypes": true,
+        "angular.inlayHints.controlFlowHints.switchExpressionTypes": true
+      }
+    }
+  }
+}
+```
+
+Notes:
+
+- **Auto-imports** (`angular.suggest.autoImports`) and a useful set of **inlay hints** are enabled by default; set the corresponding key to `false` to turn one off.
+- **`--angularCoreVersion`** is detected automatically from your project's `package.json` and forwarded to the compiler, keeping diagnostics accurate on older Angular versions — you don't need to set anything.
+- The full list of `angular.inlayHints.*` keys matches the [VSCode extension](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template) (groups: `variableTypes`, `bindingHints`, `eventHints`, `functionTypes`, `parameterHints`, `controlFlowHints`, `interaction`). Any key you set is forwarded verbatim to the language server.
+
+### Not available (yet)
+
+These rely on editor-specific command APIs that Zed does not expose to extensions, so they can't be provided here even though the VSCode extension has them:
+
+- **Go to component / Go to template** commands.
+- **View Template Typecheck Block** (`getTemplateTcb`).
+- **Restart Angular server** command (Zed manages language server restarts itself).
+
+Everything else — completions, diagnostics, hover, go-to-definition, document symbols, rename, find references, and inlay hints — comes from the shared `@angular/language-server` and works in Zed.
 
 ## Installation Instructions
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "angular"
 name = "Angular"
-description = "Angular Language support"
-version = "0.0.5"
+description = "Angular Language support with project-aware version auto-detection"
+version = "0.1.0"
 schema_version = 1
 authors = ["nathansbradshaw"]
 repository = "https://github.com/nathansbradshaw/zed-angular"

--- a/src/angular.rs
+++ b/src/angular.rs
@@ -1,31 +1,218 @@
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::collections::HashMap;
 use std::{env, fs, vec};
 use zed::lsp::{Completion, CompletionKind};
 use zed::settings::LspSettings;
 use zed::CodeLabelSpan;
 use zed_extension_api::{self as zed, serde_json, Result};
 
-// The Latest version of typescript isn't always compatible with angular see: https://angular.dev/reference/versions#unsupported-angular-versions
-const DEFAULT_ANGULAR_LANGUAGE_SERVER_VERSION: &str = "21.1.5";
+// The latest version of TypeScript isn't always compatible with Angular, see:
+// https://angular.dev/reference/versions#unsupported-angular-versions
+// These defaults are only used as a last-resort fallback when the project's
+// Angular version cannot be detected.
+const DEFAULT_ANGULAR_LANGUAGE_SERVER_VERSION: &str = "21.2.17";
 const DEFAULT_TYPESCRIPT_VERSION: &str = "5.9.3";
 
+// Path to the language server installed in the extension's own sandbox
+// (relative to the extension's working directory).
 const SERVER_PATH: &str = "node_modules/@angular/language-server/index.js";
 const TYPESCRIPT_TSDK_PATH: &str = "node_modules/typescript/lib";
+
+// Paths inside the *project's* worktree, used to detect a locally installed
+// language server and TypeScript SDK. `read_text_file` is the only filesystem
+// probe available against the worktree, so we read tiny marker files to check
+// for existence.
+const PROJECT_SERVER_REL_PATH: &str = "node_modules/@angular/language-server/index.js";
+const PROJECT_TSDK_REL_DIR: &str = "node_modules/typescript/lib";
+const PROJECT_TSDK_PROBE_FILE: &str = "node_modules/typescript/package.json";
 
 const ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME: &str = "@angular/language-server";
 const TYPESCRIPT_PACKAGE_NAME: &str = "typescript";
 
+const ANGULAR_CORE_PACKAGE_NAME: &str = "@angular/core";
+const ANGULAR_LANGUAGE_SERVICE_PACKAGE_NAME: &str = "@angular/language-service";
+
+/// Maps an Angular major version to a concrete, known-good
+/// (`@angular/language-server`, `typescript`) version pair.
+///
+/// The language-server patch is the latest published for that major; the
+/// TypeScript version is chosen comfortably inside Angular's supported range
+/// to avoid the "unsupported TypeScript version" warning. See:
+/// https://angular.dev/reference/versions
+///
+/// Majors below the lowest entry fall back to the lowest entry; majors above
+/// the highest known entry fall back to the modern defaults.
+const ANGULAR_VERSION_TABLE: &[(u32, &str, &str)] = &[
+    (13, "13.3.4", "4.6.4"),
+    (14, "14.2.0", "4.8.4"),
+    (15, "15.2.1", "4.9.5"),
+    (16, "16.2.0", "5.1.6"),
+    (17, "17.3.2", "5.4.5"),
+    (18, "18.2.0", "5.5.4"),
+    (19, "19.2.4", "5.8.3"),
+    (20, "20.3.0", "5.8.3"),
+    (21, "21.2.17", "5.9.3"),
+];
+
+/// User settings read from the language server's `initialization_options` in
+/// Zed's `settings.json`. Version keys use snake_case; the Angular feature keys
+/// mirror the dot-namespaced keys of the official VSCode extension verbatim, so
+/// configuration can be copied straight from Angular's docs.
 #[derive(Deserialize, Default)]
 struct UserSettings {
+    // Version management (existing behaviour).
     angular_language_server_version: Option<String>,
     typescript_version: Option<String>,
+
+    // Completion behaviour (forwarded as CLI flags, matching the VSCode client).
+    #[serde(rename = "angular.suggest.includeAutomaticOptionalChainCompletions")]
+    include_automatic_optional_chain_completions: Option<bool>,
+    #[serde(rename = "angular.suggest.includeCompletionsWithSnippetText")]
+    include_completions_with_snippet_text: Option<bool>,
+    /// Auto-imports. Defaults to `true` (same as VSCode) when unset.
+    #[serde(rename = "angular.suggest.autoImports")]
+    auto_imports: Option<bool>,
+
+    // Diagnostics / strictness.
+    #[serde(rename = "angular.forceStrictTemplates")]
+    force_strict_templates: Option<bool>,
+    /// Comma-separated list of diagnostic codes to suppress, e.g. "-992008,-998001".
+    #[serde(rename = "angular.suppressAngularDiagnosticCodes")]
+    suppress_angular_diagnostic_codes: Option<String>,
+
+    // File watching.
+    #[serde(rename = "angular.server.useClientSideFileWatcher")]
+    use_client_side_file_watcher: Option<bool>,
+
+    /// Catch-all for any remaining keys (notably the `angular.inlayHints.*`
+    /// family) so they can be forwarded verbatim through workspace configuration
+    /// without enumerating every one. The known keys above are captured into
+    /// their own fields and won't appear here.
+    #[serde(flatten)]
+    extra: HashMap<String, serde_json::Value>,
 }
 
-struct AngularExtension {
-    did_find_server: bool,
-    angular_language_server_version: String,
-    typescript_version: String,
+/// Minimal view of a project's `package.json` needed to detect its Angular version.
+#[derive(Deserialize, Default)]
+struct PackageJson {
+    #[serde(default)]
+    dependencies: HashMap<String, String>,
+    #[serde(default, rename = "devDependencies")]
+    dev_dependencies: HashMap<String, String>,
+}
+
+/// How the Angular Language Server should be launched for a given worktree.
+enum ServerSource {
+    /// Use the language server already installed in the project's `node_modules`.
+    /// Both paths are absolute. No npm install is performed; this guarantees an
+    /// exact version match with the project and covers monorepos automatically.
+    ProjectNodeModules {
+        index_js_abs: String,
+        tsdk_abs: String,
+    },
+    /// Install (if needed) and use the language server in the extension's sandbox
+    /// at the resolved versions.
+    Managed {
+        als_version: String,
+        ts_version: String,
+    },
+}
+
+/// Version resolution is fully per-worktree and stateless, so the extension
+/// holds no fields. A single instance may serve multiple worktrees.
+struct AngularExtension;
+
+/// A version parsed from an npm range spec.
+///
+/// Handles common forms: `"^17.3.0"`, `"~18.0.0-rc.1"`, `">=19.0.0 <20"`,
+/// `"17.3.0"`, `"v16.1.0"`, `"18.x"`. Returns `None` for non-numeric specs
+/// such as `"latest"`, `"next"`, `"*"`, `"workspace:*"`, or git/URL specs, so
+/// the caller can fall back to a sensible default.
+struct ParsedVersion {
+    /// The major version number (e.g. 17).
+    major: u32,
+    /// The concrete version token with range operators stripped (e.g. "17.3.0"),
+    /// taken up to the first whitespace so `">=17.0.0 <18"` yields `"17.0.0"`.
+    cleaned: String,
+}
+
+fn parse_version(range: &str) -> Option<ParsedVersion> {
+    let trimmed = range.trim();
+    // Find the first digit; everything before it is a range operator/prefix
+    // (`^`, `~`, `>=`, `>`, `=`, `v`, whitespace, etc.).
+    let start = trimmed.find(|c: char| c.is_ascii_digit())?;
+    // Reject specs where the prefix is clearly not a simple range operator
+    // (e.g. "workspace:1.0.0", "npm:foo@1.2.3").
+    let prefix = &trimmed[..start];
+    if prefix.contains(':') || prefix.contains('@') {
+        return None;
+    }
+
+    let cleaned: String = trimmed[start..]
+        .chars()
+        .take_while(|c| !c.is_whitespace())
+        .collect();
+
+    let major = cleaned
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect::<String>()
+        .parse::<u32>()
+        .ok()?;
+
+    Some(ParsedVersion { major, cleaned })
+}
+
+/// Inserts `value` into `root` at a dot-delimited `path`, creating intermediate
+/// objects as needed. Used to merge the user's flat VSCode-style config keys
+/// (e.g. `"angular.inlayHints.variableTypes.ifAliasTypes"`) into the nested
+/// structure the language server expects. Non-object intermediates are
+/// overwritten with objects.
+fn set_nested(root: &mut serde_json::Value, path: &str, value: serde_json::Value) {
+    let parts: Vec<&str> = path.split('.').collect();
+    let mut current = root;
+    for (i, part) in parts.iter().enumerate() {
+        if i == parts.len() - 1 {
+            if let Some(obj) = current.as_object_mut() {
+                obj.insert((*part).to_string(), value);
+            }
+            return;
+        }
+        // Descend, creating an object if the slot is missing or not an object.
+        let obj = match current.as_object_mut() {
+            Some(obj) => obj,
+            None => return,
+        };
+        let entry = obj
+            .entry((*part).to_string())
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        if !entry.is_object() {
+            *entry = serde_json::Value::Object(serde_json::Map::new());
+        }
+        current = entry;
+    }
+}
+
+/// Maps an Angular major version to concrete (`@angular/language-server`,
+/// `typescript`) versions. Returns `None` for majors above the known table,
+/// signalling the caller to use the modern defaults.
+fn map_angular_major_to_versions(major: u32) -> Option<(String, String)> {
+    let lowest = ANGULAR_VERSION_TABLE.first().expect("table is non-empty");
+    let highest = ANGULAR_VERSION_TABLE.last().expect("table is non-empty");
+
+    // Below the lowest known major: clamp to the lowest entry.
+    if major < lowest.0 {
+        return Some((lowest.1.to_string(), lowest.2.to_string()));
+    }
+    // Above the highest known major: defer to the modern defaults.
+    if major > highest.0 {
+        return None;
+    }
+
+    ANGULAR_VERSION_TABLE
+        .iter()
+        .find(|(m, _, _)| *m == major)
+        .map(|(_, als, ts)| (als.to_string(), ts.to_string()))
 }
 
 impl AngularExtension {
@@ -37,7 +224,7 @@ impl AngularExtension {
         language_server_name: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<UserSettings> {
-        let lsp_settings = LspSettings::for_worktree(&language_server_name.to_string(), worktree)?;
+        let lsp_settings = LspSettings::for_worktree(language_server_name.as_ref(), worktree)?;
 
         if let Some(options) = lsp_settings.initialization_options {
             let user_settings: UserSettings = serde_json::from_value(options)
@@ -47,56 +234,248 @@ impl AngularExtension {
             Ok(UserSettings::default())
         }
     }
+
     fn file_exists_at_path(&self, path: &str) -> bool {
-        fs::metadata(path).map_or(false, |stat| stat.is_file())
+        fs::metadata(path).is_ok_and(|stat| stat.is_file())
     }
 
-    fn server_script_path(&mut self, language_server_id: &zed::LanguageServerId) -> Result<String> {
-        let server_exists = self.file_exists_at_path(&SERVER_PATH);
+    /// Reads the project's `package.json` once and parses the Angular version
+    /// from `@angular/core` (preferred) or `@angular/language-service`.
+    /// Returns `None` if there is no `package.json` or no usable version.
+    fn detect_angular_version(worktree: &zed::Worktree) -> Option<ParsedVersion> {
+        let contents = worktree.read_text_file("package.json").ok()?;
+        let pkg: PackageJson = serde_json::from_str(&contents).ok()?;
 
-        if self.did_find_server && server_exists {
-            zed::set_language_server_installation_status(
-                language_server_id,
-                &zed::LanguageServerInstallationStatus::CheckingForUpdate,
-            );
+        let lookup = |name: &str| -> Option<&String> {
+            pkg.dependencies
+                .get(name)
+                .or_else(|| pkg.dev_dependencies.get(name))
+        };
 
-            // TODO only install new version if there are change
+        let range = lookup(ANGULAR_CORE_PACKAGE_NAME)
+            .or_else(|| lookup(ANGULAR_LANGUAGE_SERVICE_PACKAGE_NAME))?;
+
+        parse_version(range)
+    }
+
+    /// Builds the feature CLI flags forwarded to the language server, mirroring
+    /// the official VSCode client's `constructArgs`. `core_version` (when known)
+    /// is passed as `--angularCoreVersion` so the compiler stays compatible with
+    /// older Angular versions.
+    fn build_feature_args(settings: &UserSettings, core_version: Option<&str>) -> Vec<String> {
+        let mut args = Vec::new();
+
+        if settings
+            .include_automatic_optional_chain_completions
+            .unwrap_or(false)
+        {
+            args.push("--includeAutomaticOptionalChainCompletions".to_string());
         }
 
+        if settings
+            .include_completions_with_snippet_text
+            .unwrap_or(false)
+        {
+            args.push("--includeCompletionsWithSnippetText".to_string());
+        }
+
+        // Auto-imports default to true, matching the VSCode client.
+        args.push("--includeCompletionsForModuleExports".to_string());
+        args.push(settings.auto_imports.unwrap_or(true).to_string());
+
+        if settings.force_strict_templates.unwrap_or(false) {
+            args.push("--forceStrictTemplates".to_string());
+        }
+
+        if let Some(codes) = &settings.suppress_angular_diagnostic_codes {
+            if !codes.trim().is_empty() {
+                args.push("--suppressAngularDiagnosticCodes".to_string());
+                args.push(codes.clone());
+            }
+        }
+
+        if settings.use_client_side_file_watcher.unwrap_or(false) {
+            args.push("--useClientSideFileWatcher".to_string());
+        }
+
+        // Pass the project's Angular core version so the compiler targets it for
+        // maximum compatibility (e.g. it won't import v21 APIs into a v13 project).
+        if let Some(core_version) = core_version {
+            args.push("--angularCoreVersion".to_string());
+            args.push(core_version.to_string());
+        }
+
+        args
+    }
+
+    /// Builds the nested workspace configuration returned to the server.
+    ///
+    /// The Angular Language Server requests sections such as `angular.inlayHints`
+    /// via `workspace/configuration` and then flattens the *nested* object it
+    /// receives (e.g. `{variableTypes: {forLoopVariableTypes: true}}` becomes
+    /// `angular.inlayHints.variableTypes.forLoopVariableTypes`). So the config
+    /// must be nested, not dot-flattened.
+    ///
+    /// A sensible set of hints is enabled by default; any matching key the user
+    /// sets in `initialization_options` (flat, VSCode-style) overrides it.
+    /// `editor.inlayHints.enabled` must be on for the server to emit hints.
+    fn build_workspace_configuration(settings: &UserSettings) -> serde_json::Value {
+        use serde_json::json;
+
+        // Default-on inlay hints (a useful subset of the VSCode defaults),
+        // expressed as the nested object the server expects under `angular`.
+        let mut config = json!({
+            "editor": { "inlayHints": { "enabled": "on" } },
+            "angular": {
+                "inlayHints": {
+                    "variableTypes": {
+                        "forLoopVariableTypes": true,
+                        "ifAliasTypes": true,
+                        "letDeclarationTypes": true,
+                        "referenceVariableTypes": true
+                    },
+                    "bindingHints": {
+                        "pipeOutputTypes": true,
+                        "twoWayBindingSignalTypes": true
+                    },
+                    "eventHints": {
+                        "parameterTypes": true
+                    },
+                    "controlFlowHints": {
+                        "switchExpressionTypes": true
+                    }
+                }
+            }
+        });
+
+        // Apply the user's flat, dot-namespaced overrides on top by walking the
+        // dotted key into the nested structure (e.g.
+        // "angular.inlayHints.variableTypes.ifAliasTypes" -> nested path).
+        if let Some(force) = settings.force_strict_templates {
+            set_nested(&mut config, "angular.forceStrictTemplates", json!(force));
+        }
+        for (key, value) in &settings.extra {
+            set_nested(&mut config, key, value.clone());
+        }
+
+        config
+    }
+
+    /// Decides how to launch the language server for this worktree, in order of
+    /// priority: manual override -> project's own language server -> version
+    /// derived from `detected` (the parsed `package.json` version) -> defaults.
+    fn resolve_server(
+        &self,
+        worktree: &zed::Worktree,
+        settings: &UserSettings,
+        detected: Option<&ParsedVersion>,
+    ) -> ServerSource {
+        // 1. Manual override via initialization_options always wins.
+        if settings.angular_language_server_version.is_some()
+            || settings.typescript_version.is_some()
+        {
+            let als = settings
+                .angular_language_server_version
+                .clone()
+                .unwrap_or_else(|| DEFAULT_ANGULAR_LANGUAGE_SERVER_VERSION.to_string());
+            let ts = settings
+                .typescript_version
+                .clone()
+                .unwrap_or_else(|| DEFAULT_TYPESCRIPT_VERSION.to_string());
+            return ServerSource::Managed {
+                als_version: als,
+                ts_version: ts,
+            };
+        }
+
+        // 2. Prefer the language server already installed in the project, when
+        //    both it and a local TypeScript SDK are present. Guarantees an exact
+        //    match and covers monorepos (nx/pnpm hoisted node_modules).
+        let has_project_server = worktree.read_text_file(PROJECT_SERVER_REL_PATH).is_ok();
+        let has_project_tsdk = worktree.read_text_file(PROJECT_TSDK_PROBE_FILE).is_ok();
+        if has_project_server && has_project_tsdk {
+            let root = worktree.root_path();
+            return ServerSource::ProjectNodeModules {
+                index_js_abs: format!("{root}/{PROJECT_SERVER_REL_PATH}"),
+                tsdk_abs: format!("{root}/{PROJECT_TSDK_REL_DIR}"),
+            };
+        }
+
+        // 3. Derive a compatible version from the detected Angular version.
+        if let Some((als, ts)) = detected.and_then(|v| map_angular_major_to_versions(v.major)) {
+            return ServerSource::Managed {
+                als_version: als,
+                ts_version: ts,
+            };
+        }
+
+        // 4. Fallback to modern defaults.
+        ServerSource::Managed {
+            als_version: DEFAULT_ANGULAR_LANGUAGE_SERVER_VERSION.to_string(),
+            ts_version: DEFAULT_TYPESCRIPT_VERSION.to_string(),
+        }
+    }
+
+    /// Ensures the language server is installed in the extension's sandbox at the
+    /// requested versions and returns the (relative) path to its `index.js`.
+    fn ensure_managed_server(
+        &self,
+        language_server_id: &zed::LanguageServerId,
+        als_version: &str,
+        ts_version: &str,
+    ) -> Result<String> {
         zed::set_language_server_installation_status(
             language_server_id,
-            &zed::LanguageServerInstallationStatus::Downloading,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
 
-        self.install_packages()?;
+        self.install_packages(als_version, ts_version)?;
 
-        if !self.file_exists_at_path(&SERVER_PATH) {
+        if !self.file_exists_at_path(SERVER_PATH) {
             return Err(format!(
                 "Installed package '{}' did not contain expected path '{}'",
                 ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME, SERVER_PATH
-            )
-            .into());
+            ));
         }
 
-        self.did_find_server = true;
         Ok(SERVER_PATH.to_string())
     }
 
-    fn install_packages(&mut self) -> Result<()> {
-        let als_version = if self.angular_language_server_version == "latest" {
+    fn install_packages(&self, als_version: &str, ts_version: &str) -> Result<()> {
+        let als_version = if als_version == "latest" {
             zed::npm_package_latest_version(ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME)?
         } else {
-            self.angular_language_server_version.clone()
+            als_version.to_string()
         };
 
-        let ts_version = if self.typescript_version == "latest" {
+        let ts_version = if ts_version == "latest" {
             zed::npm_package_latest_version(TYPESCRIPT_PACKAGE_NAME)?
         } else {
-            self.typescript_version.clone()
+            ts_version.to_string()
         };
 
+        // Only (re)install when the currently installed version differs from the
+        // target, so unchanged projects don't trigger a download on every start.
+        let als_installed =
+            zed::npm_package_installed_version(ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME)?;
+        let ts_installed = zed::npm_package_installed_version(TYPESCRIPT_PACKAGE_NAME)?;
+
+        let als_up_to_date = als_installed.as_deref() == Some(als_version.as_str());
+        let ts_up_to_date = ts_installed.as_deref() == Some(ts_version.as_str());
+
+        if als_up_to_date && ts_up_to_date && self.file_exists_at_path(SERVER_PATH) {
+            println!(
+                "[angular] {}@{} and {}@{} already installed; skipping",
+                ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME,
+                als_version,
+                TYPESCRIPT_PACKAGE_NAME,
+                ts_version
+            );
+            return Ok(());
+        }
+
         println!(
-            "Installing {}@{}, {}@{}",
+            "[angular] Installing {}@{}, {}@{}",
             ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME, als_version, TYPESCRIPT_PACKAGE_NAME, ts_version
         );
 
@@ -118,46 +497,22 @@ impl AngularExtension {
         Ok(())
     }
 
-    fn get_current_dir() -> Result<PathBuf> {
-        env::current_dir().map_err(|e| format!("Failed to get current directory: {}", e))
-    }
-
-    fn get_ng_probe_locations(worktree: Option<&zed::Worktree>) -> Vec<String> {
+    /// Locations the language server probes to find TypeScript and Angular: the
+    /// extension's own working directory and the project root. Used for both
+    /// `--tsProbeLocations` and `--ngProbeLocations`.
+    fn probe_locations(worktree: &zed::Worktree) -> Vec<String> {
         let mut paths = vec![];
-
-        if let Ok(path) = Self::get_current_dir() {
-            paths.push(path.to_string_lossy().to_string());
+        if let Ok(dir) = env::current_dir() {
+            paths.push(dir.to_string_lossy().to_string());
         }
-
-        if let Some(worktree) = worktree {
-            paths.push(worktree.root_path());
-        }
-
-        paths
-    }
-
-    fn get_ts_probe_locations(worktree: Option<&zed::Worktree>) -> Vec<String> {
-        let mut paths = vec![];
-
-        if let Ok(path) = Self::get_current_dir() {
-            paths.push(path.to_string_lossy().to_string());
-        }
-
-        if let Some(worktree) = worktree {
-            paths.push(worktree.root_path());
-        }
-
+        paths.push(worktree.root_path());
         paths
     }
 }
 
 impl zed::Extension for AngularExtension {
     fn new() -> Self {
-        Self {
-            did_find_server: false,
-            angular_language_server_version: DEFAULT_ANGULAR_LANGUAGE_SERVER_VERSION.to_owned(),
-            typescript_version: DEFAULT_TYPESCRIPT_VERSION.to_owned(),
-        }
+        Self
     }
 
     fn language_server_command(
@@ -167,29 +522,61 @@ impl zed::Extension for AngularExtension {
     ) -> Result<zed::Command> {
         let user_settings = self.read_user_settings(language_server_id, worktree)?;
 
-        if let Some(version) = user_settings.angular_language_server_version {
-            self.angular_language_server_version = version;
-        }
+        // Read the project's Angular version once; both server resolution and
+        // the feature flags below reuse it.
+        let detected = Self::detect_angular_version(worktree);
 
-        if let Some(version) = user_settings.typescript_version {
-            self.typescript_version = version;
-        }
+        // Resolve which language server to run for this project, then build the
+        // launch command. `index_js` is an absolute path to the server entry;
+        // `tsdk` is the TypeScript lib directory passed to `--tsdk`.
+        let (index_js, tsdk) = match self.resolve_server(
+            worktree,
+            &user_settings,
+            detected.as_ref(),
+        ) {
+            ServerSource::ProjectNodeModules {
+                index_js_abs,
+                tsdk_abs,
+            } => {
+                println!("[angular] Using language server from project node_modules");
+                (index_js_abs, tsdk_abs)
+            }
+            ServerSource::Managed {
+                als_version,
+                ts_version,
+            } => {
+                println!(
+                        "[angular] Using @angular/language-server@{als_version} with typescript@{ts_version}"
+                    );
+                let server_path =
+                    self.ensure_managed_server(language_server_id, &als_version, &ts_version)?;
+                let current_dir = env::current_dir().unwrap_or_default();
+                let full_path_to_server = current_dir.join(&server_path);
+                (
+                    full_path_to_server.to_string_lossy().to_string(),
+                    TYPESCRIPT_TSDK_PATH.to_string(),
+                )
+            }
+        };
 
-        let server_path = self.server_script_path(language_server_id)?;
-        let current_dir = env::current_dir().unwrap_or(PathBuf::new());
-        let full_path_to_server = current_dir.join(&server_path);
-
-        let mut args = vec![full_path_to_server.to_string_lossy().to_string()];
+        let mut args = vec![index_js];
         args.push("--stdio".to_string());
 
+        let probe_locations = Self::probe_locations(worktree);
         args.push("--tsProbeLocations".to_string());
-        args.extend(Self::get_ts_probe_locations(Some(worktree)));
+        args.extend(probe_locations.iter().cloned());
 
         args.push("--ngProbeLocations".to_string());
-        args.extend(Self::get_ng_probe_locations(Some(worktree)));
+        args.extend(probe_locations);
 
         args.push("--tsdk".to_string());
-        args.push(TYPESCRIPT_TSDK_PATH.to_string());
+        args.push(tsdk);
+
+        // Forward feature flags derived from the user's settings and the
+        // detected Angular version (completions, strict templates, suppressed
+        // diagnostics, --angularCoreVersion, …), mirroring the VSCode client.
+        let core_version = detected.as_ref().map(|v| v.cleaned.as_str());
+        args.extend(Self::build_feature_args(&user_settings, core_version));
 
         Ok(zed::Command {
             command: zed::node_binary_path()?,
@@ -198,12 +585,24 @@ impl zed::Extension for AngularExtension {
         })
     }
 
+    /// Responds to the server's `workspace/configuration` requests with the
+    /// `angular` section. The Angular Language Server fetches inlay-hint
+    /// settings dynamically through this channel, so returning them here is what
+    /// makes inlay hints configurable (and on by default).
+    fn language_server_workspace_configuration(
+        &mut self,
+        language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = self.read_user_settings(language_server_id, worktree)?;
+        Ok(Some(Self::build_workspace_configuration(&settings)))
+    }
+
     fn label_for_completion(
         &self,
         _language_server_id: &zed::LanguageServerId,
         completion: Completion,
     ) -> Option<zed::CodeLabel> {
-        println!("Label for completion {:?}", completion.kind);
         let highlight_name = match completion.kind? {
             CompletionKind::Class | CompletionKind::Interface => "type",
             CompletionKind::Constructor => "constructor",
@@ -239,3 +638,123 @@ impl zed::Extension for AngularExtension {
 }
 
 zed::register_extension!(AngularExtension);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: assert a range parses to the given (major, cleaned) pair.
+    fn assert_parsed(range: &str, major: u32, cleaned: &str) {
+        let parsed = parse_version(range).expect("should parse");
+        assert_eq!(parsed.major, major, "major for {range:?}");
+        assert_eq!(parsed.cleaned, cleaned, "cleaned for {range:?}");
+    }
+
+    #[test]
+    fn parses_common_version_ranges() {
+        assert_parsed("^17.3.0", 17, "17.3.0");
+        assert_parsed("~18.0.0-rc.1", 18, "18.0.0-rc.1");
+        assert_parsed(">=19.0.0 <20.0.0", 19, "19.0.0");
+        assert_parsed("17.3.0", 17, "17.3.0");
+        assert_parsed("v16.1.0", 16, "16.1.0");
+        assert_parsed("18.x", 18, "18.x");
+        assert_parsed("  ^20.0.0  ", 20, "20.0.0");
+        assert_parsed("21", 21, "21");
+    }
+
+    #[test]
+    fn rejects_non_numeric_ranges() {
+        for range in [
+            "latest",
+            "next",
+            "*",
+            "workspace:*",
+            "npm:@angular/core@17.0.0",
+            "",
+        ] {
+            assert!(parse_version(range).is_none(), "{range:?} should not parse");
+        }
+    }
+
+    #[test]
+    fn maps_known_majors_to_versions() {
+        assert_eq!(
+            map_angular_major_to_versions(17),
+            Some(("17.3.2".to_string(), "5.4.5".to_string()))
+        );
+        assert_eq!(
+            map_angular_major_to_versions(13),
+            Some(("13.3.4".to_string(), "4.6.4".to_string()))
+        );
+        assert_eq!(
+            map_angular_major_to_versions(21),
+            Some(("21.2.17".to_string(), "5.9.3".to_string()))
+        );
+    }
+
+    #[test]
+    fn clamps_below_lowest_and_defers_above_highest() {
+        // Below the lowest known major clamps to the oldest entry (v13).
+        assert_eq!(
+            map_angular_major_to_versions(11),
+            Some(("13.3.4".to_string(), "4.6.4".to_string()))
+        );
+        // Newer than the table -> defer to defaults.
+        assert_eq!(map_angular_major_to_versions(99), None);
+    }
+
+    #[test]
+    fn set_nested_creates_and_overrides_paths() {
+        use serde_json::json;
+
+        let mut root =
+            json!({ "angular": { "inlayHints": { "variableTypes": { "ifAliasTypes": true } } } });
+
+        // Override an existing leaf.
+        set_nested(
+            &mut root,
+            "angular.inlayHints.variableTypes.ifAliasTypes",
+            json!(false),
+        );
+        assert_eq!(
+            root["angular"]["inlayHints"]["variableTypes"]["ifAliasTypes"],
+            json!(false)
+        );
+
+        // Create a brand-new nested path.
+        set_nested(
+            &mut root,
+            "angular.inlayHints.bindingHints.pipeOutputTypes",
+            json!(true),
+        );
+        assert_eq!(
+            root["angular"]["inlayHints"]["bindingHints"]["pipeOutputTypes"],
+            json!(true)
+        );
+    }
+
+    #[test]
+    fn workspace_configuration_enables_hints_by_default() {
+        let settings = UserSettings::default();
+        let config = AngularExtension::build_workspace_configuration(&settings);
+        assert_eq!(config["editor"]["inlayHints"]["enabled"], "on");
+        assert_eq!(
+            config["angular"]["inlayHints"]["variableTypes"]["forLoopVariableTypes"],
+            true
+        );
+    }
+
+    #[test]
+    fn workspace_configuration_respects_user_override() {
+        let mut settings = UserSettings::default();
+        settings.extra.insert(
+            "angular.inlayHints.variableTypes.forLoopVariableTypes".to_string(),
+            serde_json::json!(false),
+        );
+        let config = AngularExtension::build_workspace_configuration(&settings);
+        assert_eq!(
+            config["angular"]["inlayHints"]["variableTypes"]["forLoopVariableTypes"],
+            false
+        );
+    }
+}


### PR DESCRIPTION
This makes the extension configure itself from the project, fixing a common pain point: it currently pins a fixed, modern `@angular/language-server` + `typescript` pair, which breaks on projects using older Angular — the modern language server is incompatible with the project's code and `tsconfig`, so completions, diagnostics and navigation fail.

## What it does

The extension now works from Angular 13 up to the latest release with no manual setup, while keeping the manual override as an option. Version resolution order:

1. **Manual override** in `initialization_options` (unchanged behaviour).
2. **The project's own** `@angular/language-server` + `typescript` in `node_modules`, when present (exact match, covers monorepos, no download).
3. **Derived from `package.json`** — a compatible language-server + TypeScript pair derived from the `@angular/core` version.
4. **A modern default** when nothing can be detected.

It also forwards the Angular Language Service settings like the official VSCode extension (`Angular.ng-template`):

- Feature flags: `forceStrictTemplates`, `suggest.autoImports`, snippet / optional-chain completions, suppressed diagnostic codes.
- `--angularCoreVersion`, detected from the project's `package.json`, so diagnostics stay accurate on older Angular.
- Inlay hints (on by default, configurable via `initialization_options` using the same dot-namespaced keys as the VSCode extension).

## Quality

- Builds clean on `wasm32-wasip2`, no `clippy` warnings, `cargo fmt` clean.
- Adds 7 unit tests (version parsing, major->versions mapping, workspace-configuration builder).
- Verified live on a real Angular 18 project: detected `@angular/core` 18.2.9, resolved language server 18.2.0 + TypeScript 5.5.4, template completions/diagnostics working.

## Notes

- Identity untouched: no changes to `id`, `authors`, `repository` or `LICENSE`. Only `version` (0.0.5 -> 0.1.0) and the extension `description` were bumped alongside the feature.
- The internal language server name stays `angular`, so existing `settings.json` keep working.

Happy to adjust anything — naming, the version table, or how settings are surfaced.