### PR TITLE
feat: add max_ts_server_memory initialization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ Please ensure your project's Angular and TypeScript versions are compatible to a
 
 Refer to [Angular Version Compatibility](https://angular.dev/reference/versions#unsupported-angular-versions) for details.
 
+## Memory
+
+In large workspaces (e.g. monorepos), the language server can exceed node's default heap limit (~4 GB) and crash repeatedly. If the server keeps restarting or stops responding after a few minutes, raise the limit with `max_ts_server_memory` (in MB, passed to node as `--max-old-space-size`):
+
+```json
+{
+  "lsp": {
+    "angular": {
+      "initialization_options": {
+        "max_ts_server_memory": 8192
+      }
+    }
+  }
+}
+```
+
 ## Installation Instructions
 
 To install this extension locally:

--- a/src/angular.rs
+++ b/src/angular.rs
@@ -12,6 +12,14 @@ const TYPESCRIPT_TSDK_PATH: &str = "node_modules/typescript/lib";
 const ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME: &str = "@angular/language-server";
 const TYPESCRIPT_PACKAGE_NAME: &str = "typescript";
 
+#[derive(Deserialize, Default)]
+struct UserSettings {
+    /// Maximum heap size (in MB) for the language server process, passed to
+    /// node as `--max-old-space-size`. Useful in large monorepos where the
+    /// server exceeds node's default (~4 GB) heap limit and crashes.
+    max_ts_server_memory: Option<u32>,
+}
+
 struct AngularExtension {
     did_find_server: bool,
 }
@@ -93,11 +101,25 @@ impl zed::Extension for AngularExtension {
         language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
+        let user_settings: UserSettings =
+            LspSettings::for_worktree(&language_server_id.to_string(), worktree)?
+            .initialization_options
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|e| format!("Failed to parse initialization_options: {}", e))?
+            .unwrap_or_default();
+
         let server_path = self.server_script_path(language_server_id)?;
         let current_dir = env::current_dir().unwrap_or_else(|_| PathBuf::new());
         let full_path_to_server = current_dir.join(&server_path);
 
-        let mut args = vec![full_path_to_server.to_string_lossy().to_string()];
+        let mut args = vec![];
+
+        if let Some(max_memory) = user_settings.max_ts_server_memory {
+            args.push(format!("--max-old-space-size={}", max_memory));
+        }
+
+        args.push(full_path_to_server.to_string_lossy().to_string());
         args.push("--stdio".to_string());
 
         // Probe paths: This tells the language-server where to seek and resolve "typescript/lib/tsserverlibrary"


### PR DESCRIPTION
## Problem

In large workspaces (e.g. Nx monorepos), the Angular language server exceeds node's default heap limit (~4 GB) while loading the project graph and crashes. Zed restarts it, it crashes again — an endless loop where template navigation and completions never work. In Zed's logs this shows up as escalating request timeouts followed by:

```
Get definition via angular failed: Server reset the connection
Broken pipe (os error 32)
... via angular failed: server shut down
```

On my Angular 19 monorepo (~10 apps, ~20 libs) the server died every ~3 minutes, 11 restarts in a day, and was effectively unusable. Other node-based servers in Zed already handle this — e.g. Zed launches eslint with `--max-old-space-size=8192`, and vtsls exposes `maxTsServerMemory`.

## Change

Adds an opt-in `max_ts_server_memory` initialization option (in MB), passed to node as `--max-old-space-size`, following the same pattern as the existing `angular_language_server_version` / `typescript_version` options:

```json
{
  "lsp": {
    "angular": {
      "initialization_options": {
        "max_ts_server_memory": 8192
      }
    }
  }
}
```

Left unset, behavior is unchanged.

## Testing

- `cargo build` and `cargo fmt -- --check` pass.
- Installed as a dev extension and verified against the monorepo that exposed the problem: the server launches with `--max-old-space-size=8192` and stays alive well past the point where it previously OOM-crashed; template go-to-definition works.
- README section added documenting the option.