### PR TITLE
Only use local project's version of angular and typescript, don't download angular anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,24 +14,11 @@ This extension integrates the Angular Language Service into Zed. It uses the sam
 
 ## Version Management
 
-The extension depends on `@angular/language-service` and `typescript` Node packages. By default, these versions are managed internally, but they can be customized using the following settings:
+The extension depends on `@angular/language-service` and `typescript` Node packages. It will use whatever versions of each that are available locally in your project.
 
-```json
-{
-  "lsp": {
-    "angular": {
-      "initialization_options": {
-        "angular_language_server_version": "17.3.0",
-        "typescript_version": "5.3.2"
-      }
-    }
-  }
-}
-```
+Please ensure your project's Angular and TypeScript versions are compatible to avoid issues.
 
-Please ensure the versions of Angular and TypeScript are compatible to avoid issues.
-
-Refer to [Angular Version Compatibility](https://angular.dev/reference/versions#unsupported-angular-versions) for details. Mismatched versions may lead to bugs, so it is not recommended to use `latest` as a version, but it's also a valid option.
+Refer to [Angular Version Compatibility](https://angular.dev/reference/versions#unsupported-angular-versions) for details.
 
 ## Installation Instructions
 

--- a/src/angular.rs
+++ b/src/angular.rs
@@ -122,32 +122,29 @@ impl AngularExtension {
         env::current_dir().map_err(|e| format!("Failed to get current directory: {}", e))
     }
 
-    fn get_ng_probe_locations(worktree: Option<&zed::Worktree>) -> Vec<String> {
+    fn get_ng_probe_locations(worktree: &zed::Worktree) -> Vec<String> {
         let mut paths = vec![];
 
-        if let Ok(path) = Self::get_current_dir() {
-            paths.push(path.to_string_lossy().to_string());
-        }
+        // 1. Probe the open project's root folder (where the user's local node_modules lives)
+        paths.push(worktree.root_path());
 
-        if let Some(worktree) = worktree {
-            paths.push(worktree.root_path());
+        // 2. Probe the project's sub node_modules directory explicitly
+        let project_node_modules = PathBuf::from(worktree.root_path()).join("node_modules");
+        paths.push(project_node_modules.to_string_lossy().to_string());
+
+        // 3. Probe the Zed extension's own node_modules directory as a fallback
+        if let Ok(current_dir) = Self::get_current_dir() {
+            let ext_node_modules = current_dir.join("node_modules");
+            paths.push(ext_node_modules.to_string_lossy().to_string());
+            paths.push(current_dir.to_string_lossy().to_string());
         }
 
         paths
     }
 
-    fn get_ts_probe_locations(worktree: Option<&zed::Worktree>) -> Vec<String> {
-        let mut paths = vec![];
-
-        if let Ok(path) = Self::get_current_dir() {
-            paths.push(path.to_string_lossy().to_string());
-        }
-
-        if let Some(worktree) = worktree {
-            paths.push(worktree.root_path());
-        }
-
-        paths
+    fn get_ts_probe_locations(worktree: &zed::Worktree) -> Vec<String> {
+        // Use the exact same resolution rules for TypeScript probing
+        Self::get_ng_probe_locations(worktree)
     }
 }
 
@@ -176,20 +173,23 @@ impl zed::Extension for AngularExtension {
         }
 
         let server_path = self.server_script_path(language_server_id)?;
-        let current_dir = env::current_dir().unwrap_or(PathBuf::new());
+        let current_dir = env::current_dir().unwrap_or_else(|_| PathBuf::new());
         let full_path_to_server = current_dir.join(&server_path);
 
         let mut args = vec![full_path_to_server.to_string_lossy().to_string()];
         args.push("--stdio".to_string());
 
+        // Probe paths: This tells the language-server where to seek and resolve "typescript/lib/tsserverlibrary"
         args.push("--tsProbeLocations".to_string());
-        args.extend(Self::get_ts_probe_locations(Some(worktree)));
+        args.push(Self::get_ts_probe_locations(worktree).join(","));
 
         args.push("--ngProbeLocations".to_string());
-        args.extend(Self::get_ng_probe_locations(Some(worktree)));
+        args.push(Self::get_ng_probe_locations(worktree).join(","));
 
+        // Provide the fallback SDK path inside the extension environment
+        let absolute_tsdk_path = current_dir.join(TYPESCRIPT_TSDK_PATH);
         args.push("--tsdk".to_string());
-        args.push(TYPESCRIPT_TSDK_PATH.to_string());
+        args.push(absolute_tsdk_path.to_string_lossy().to_string());
 
         Ok(zed::Command {
             command: zed::node_binary_path()?,

--- a/src/angular.rs
+++ b/src/angular.rs
@@ -6,61 +6,32 @@ use zed::settings::LspSettings;
 use zed::CodeLabelSpan;
 use zed_extension_api::{self as zed, serde_json, Result};
 
-// The Latest version of typescript isn't always compatible with angular see: https://angular.dev/reference/versions#unsupported-angular-versions
-const DEFAULT_ANGULAR_LANGUAGE_SERVER_VERSION: &str = "21.1.5";
-const DEFAULT_TYPESCRIPT_VERSION: &str = "5.9.3";
-
 const SERVER_PATH: &str = "node_modules/@angular/language-server/index.js";
 const TYPESCRIPT_TSDK_PATH: &str = "node_modules/typescript/lib";
 
 const ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME: &str = "@angular/language-server";
 const TYPESCRIPT_PACKAGE_NAME: &str = "typescript";
 
-#[derive(Deserialize, Default)]
-struct UserSettings {
-    angular_language_server_version: Option<String>,
-    typescript_version: Option<String>,
-}
-
 struct AngularExtension {
     did_find_server: bool,
-    angular_language_server_version: String,
-    typescript_version: String,
 }
 
 impl AngularExtension {
     #[allow(dead_code)]
     pub const LANGUAGE_SERVER_ID: &'static str = "angular";
 
-    fn read_user_settings(
-        &self,
-        language_server_name: &zed::LanguageServerId,
-        worktree: &zed::Worktree,
-    ) -> Result<UserSettings> {
-        let lsp_settings = LspSettings::for_worktree(&language_server_name.to_string(), worktree)?;
-
-        if let Some(options) = lsp_settings.initialization_options {
-            let user_settings: UserSettings = serde_json::from_value(options)
-                .map_err(|e| format!("Failed to parse initialization_options: {}", e))?;
-            Ok(user_settings)
-        } else {
-            Ok(UserSettings::default())
-        }
-    }
     fn file_exists_at_path(&self, path: &str) -> bool {
         fs::metadata(path).map_or(false, |stat| stat.is_file())
     }
 
     fn server_script_path(&mut self, language_server_id: &zed::LanguageServerId) -> Result<String> {
-        let server_exists = self.file_exists_at_path(&SERVER_PATH);
+        let server_exists = self.file_exists_at_path(SERVER_PATH);
 
         if self.did_find_server && server_exists {
             zed::set_language_server_installation_status(
                 language_server_id,
                 &zed::LanguageServerInstallationStatus::CheckingForUpdate,
             );
-
-            // TODO only install new version if there are change
         }
 
         zed::set_language_server_installation_status(
@@ -68,54 +39,16 @@ impl AngularExtension {
             &zed::LanguageServerInstallationStatus::Downloading,
         );
 
-        self.install_packages()?;
-
-        if !self.file_exists_at_path(&SERVER_PATH) {
+        if !self.file_exists_at_path(SERVER_PATH) {
             return Err(format!(
-                "Installed package '{}' did not contain expected path '{}'",
-                ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME, SERVER_PATH
+                "Expected Angular language server path '{}' was not found in the project. Please ensure '{}' is installed in your project's node_modules.",
+                SERVER_PATH, ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME
             )
             .into());
         }
 
         self.did_find_server = true;
         Ok(SERVER_PATH.to_string())
-    }
-
-    fn install_packages(&mut self) -> Result<()> {
-        let als_version = if self.angular_language_server_version == "latest" {
-            zed::npm_package_latest_version(ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME)?
-        } else {
-            self.angular_language_server_version.clone()
-        };
-
-        let ts_version = if self.typescript_version == "latest" {
-            zed::npm_package_latest_version(TYPESCRIPT_PACKAGE_NAME)?
-        } else {
-            self.typescript_version.clone()
-        };
-
-        println!(
-            "Installing {}@{}, {}@{}",
-            ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME, als_version, TYPESCRIPT_PACKAGE_NAME, ts_version
-        );
-
-        zed::npm_install_package(ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME, &als_version).map_err(
-            |error| {
-                format!(
-                    "Failed to install package '{}': {}",
-                    ANGULAR_LANGUAGE_SERVER_PACKAGE_NAME, error
-                )
-            },
-        )?;
-        zed::npm_install_package(TYPESCRIPT_PACKAGE_NAME, &ts_version).map_err(|error| {
-            format!(
-                "Failed to install package '{}': {}",
-                TYPESCRIPT_PACKAGE_NAME, error
-            )
-        })?;
-
-        Ok(())
     }
 
     fn get_current_dir() -> Result<PathBuf> {
@@ -152,8 +85,6 @@ impl zed::Extension for AngularExtension {
     fn new() -> Self {
         Self {
             did_find_server: false,
-            angular_language_server_version: DEFAULT_ANGULAR_LANGUAGE_SERVER_VERSION.to_owned(),
-            typescript_version: DEFAULT_TYPESCRIPT_VERSION.to_owned(),
         }
     }
 
@@ -162,16 +93,6 @@ impl zed::Extension for AngularExtension {
         language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
-        let user_settings = self.read_user_settings(language_server_id, worktree)?;
-
-        if let Some(version) = user_settings.angular_language_server_version {
-            self.angular_language_server_version = version;
-        }
-
-        if let Some(version) = user_settings.typescript_version {
-            self.typescript_version = version;
-        }
-
         let server_path = self.server_script_path(language_server_id)?;
         let current_dir = env::current_dir().unwrap_or_else(|_| PathBuf::new());
         let full_path_to_server = current_dir.join(&server_path);
@@ -186,7 +107,7 @@ impl zed::Extension for AngularExtension {
         args.push("--ngProbeLocations".to_string());
         args.push(Self::get_ng_probe_locations(worktree).join(","));
 
-        // Provide the fallback SDK path inside the extension environment
+        // Provide the SDK path inside the project's folder hierarchy
         let absolute_tsdk_path = current_dir.join(TYPESCRIPT_TSDK_PATH);
         args.push("--tsdk".to_string());
         args.push(absolute_tsdk_path.to_string_lossy().to_string());


### PR DESCRIPTION
fixes #92 

This extension is unnecessarily downloading angular and typescript, when angular projects will always have those dependencies available (and at the correct version) in their node_modules folder.

This PR simplifies things by:

- just using the local versions available
- no longer trying to download angular anymore

This is simplify maintenance of the extension and make it more flexible and future proof at the same time.