### PR TITLE
fix: report a usable error when @angular/language-server is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ npm install --save-dev @angular/language-server typescript
 
 By default the extension looks for the package at `node_modules/@angular/language-server`, relative to the root of the worktree you have open in Zed.
 
+If the package is not at that location, the extension falls back to node's own module resolution from the worktree root. Node walks up the directory tree, so a workspace that hoists the package to a parent `node_modules` works without extra configuration. If both attempts fail, the extension reports the locations it tried and the command that installs the package.
+
 ## Version Management
 
 The extension depends on the `@angular/language-server` and `typescript` Node packages. It will use whatever versions of each that are available locally in your project.

--- a/src/angular.rs
+++ b/src/angular.rs
@@ -7,6 +7,12 @@ use zed_extension_api::{self as zed, serde_json, Result};
 /// Default location of the language server package, relative to the worktree root.
 const DEFAULT_SERVER_DIR: &str = "node_modules/@angular/language-server";
 
+/// Name of the environment variable that carries the worktree root to the
+/// preamble. Passing the root through the environment instead of inlining it
+/// keeps [`LOADER_SCRIPT`] a compile-time constant: nothing is ever
+/// concatenated into the string that node evaluates.
+const WORKTREE_ROOT_ENV: &str = "ZED_ANGULAR_WORKTREE_ROOT";
+
 /// A `node --eval` preamble that loads the language server entry point passed
 /// as `process.argv[1]`.
 ///
@@ -21,10 +27,13 @@ const DEFAULT_SERVER_DIR: &str = "node_modules/@angular/language-server";
 ///    therefore finds the package when a workspace hoists it to a parent
 ///    `node_modules`. A literal path cannot express that layout.
 ///
-/// `__ROOT__` is replaced with a JSON-quoted worktree root by [`loader_script`].
+/// This string is a constant. It is never templated, formatted, or joined with
+/// a value that comes from the worktree or from user settings. The worktree
+/// root arrives at runtime through [`WORKTREE_ROOT_ENV`], so no path can reach
+/// the evaluated source.
 const LOADER_SCRIPT: &str = r#"
 const requested = process.argv[1];
-const root = __ROOT__;
+const root = process.env.ZED_ANGULAR_WORKTREE_ROOT || process.cwd();
 let entry;
 try {
   entry = require.resolve(requested);
@@ -55,7 +64,10 @@ try {
   }
 }
 process.argv[1] = entry;
-require(entry);
+// Load the entry point as the main module. A plain `require()` under `--eval`
+// leaves `require.main` undefined, so an entry point guarded by
+// `require.main === module` would load and then do nothing.
+require("module")._load(entry, null, true);
 "#;
 
 #[derive(Deserialize, Default)]
@@ -101,17 +113,6 @@ impl AngularExtension {
             }
             None => path.to_string(),
         }
-    }
-
-    /// Build the `node --eval` preamble with the worktree root inlined.
-    ///
-    /// The root goes through `serde_json` so that separators and quote
-    /// characters in the path stay correct. A JSON string is also a valid
-    /// JavaScript string.
-    fn loader_script(root: &str) -> String {
-        let root_literal =
-            serde_json::to_string(root).unwrap_or_else(|_| String::from("process.cwd()"));
-        LOADER_SCRIPT.replace("__ROOT__", &root_literal)
     }
 
     /// Resolve the language server package directory to an absolute path.
@@ -203,7 +204,7 @@ impl zed::Extension for AngularExtension {
         // The preamble runs before the server and keeps `process.argv` intact.
         // `--` stops node from reading the server flags as its own.
         args.push("--eval".into());
-        args.push(Self::loader_script(&root));
+        args.push(LOADER_SCRIPT.into());
         args.push("--".into());
 
         args.push(format!("{server_dir}/index.js"));
@@ -216,10 +217,20 @@ impl zed::Extension for AngularExtension {
         args.push("--logVerbosity".into());
         args.push("normal".into());
 
+        // The preamble reads the root from the environment rather than having it
+        // baked into the evaluated source. Drop any inherited value so the
+        // shell cannot decide where the extension looks for the package.
+        let mut env = worktree.shell_env();
+        env.retain(|(key, _)| key != WORKTREE_ROOT_ENV);
+        env.push((
+            WORKTREE_ROOT_ENV.to_string(),
+            root.trim_end_matches('/').to_string(),
+        ));
+
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args,
-            env: worktree.shell_env(),
+            env,
         })
     }
 

--- a/src/angular.rs
+++ b/src/angular.rs
@@ -7,6 +7,57 @@ use zed_extension_api::{self as zed, serde_json, Result};
 /// Default location of the language server package, relative to the worktree root.
 const DEFAULT_SERVER_DIR: &str = "node_modules/@angular/language-server";
 
+/// A `node --eval` preamble that loads the language server entry point passed
+/// as `process.argv[1]`.
+///
+/// The preamble leaves `process.argv` identical to a plain `node <entry>`
+/// invocation, so the server parses its own flags unchanged. It has two jobs:
+///
+/// 1. Replace node's bare `MODULE_NOT_FOUND` stack trace with a message that
+///    names the missing package and the command that installs it. The stack
+///    trace mentions neither this extension nor `@angular/language-server`
+///    as something the user must install.
+/// 2. Fall back to node's own resolver, which walks up the directory tree and
+///    therefore finds the package when a workspace hoists it to a parent
+///    `node_modules`. A literal path cannot express that layout.
+///
+/// `__ROOT__` is replaced with a JSON-quoted worktree root by [`loader_script`].
+const LOADER_SCRIPT: &str = r#"
+const requested = process.argv[1];
+const root = __ROOT__;
+let entry;
+try {
+  entry = require.resolve(requested);
+} catch (_) {
+  try {
+    entry = require.resolve("@angular/language-server", { paths: [root] });
+  } catch (_) {
+    console.error([
+      "The Angular extension cannot find the @angular/language-server package.",
+      "",
+      "It looked in these locations:",
+      "  " + requested,
+      "  node module resolution from " + root,
+      "",
+      "The extension does not download a language server. Install the package",
+      "in your project:",
+      "",
+      "  npm install --save-dev @angular/language-server typescript",
+      "",
+      "The major version of @angular/language-server must be equal to the major",
+      "version of Angular in your project.",
+      "",
+      "If the package is in a different location, set the location in your Zed",
+      "settings with this option:",
+      "  lsp.angular.initialization_options.angular_language_server_path",
+    ].join("\n"));
+    process.exit(1);
+  }
+}
+process.argv[1] = entry;
+require(entry);
+"#;
+
 #[derive(Deserialize, Default)]
 struct UserSettings {
     /// Maximum heap size (in MB) for the language server process, passed to
@@ -50,6 +101,17 @@ impl AngularExtension {
             }
             None => path.to_string(),
         }
+    }
+
+    /// Build the `node --eval` preamble with the worktree root inlined.
+    ///
+    /// The root goes through `serde_json` so that separators and quote
+    /// characters in the path stay correct. A JSON string is also a valid
+    /// JavaScript string.
+    fn loader_script(root: &str) -> String {
+        let root_literal =
+            serde_json::to_string(root).unwrap_or_else(|_| String::from("process.cwd()"));
+        LOADER_SCRIPT.replace("__ROOT__", &root_literal)
     }
 
     /// Resolve the language server package directory to an absolute path.
@@ -137,6 +199,12 @@ impl zed::Extension for AngularExtension {
         if let Some(mb) = settings.max_ts_server_memory {
             args.push(format!("--max-old-space-size={mb}"));
         }
+
+        // The preamble runs before the server and keeps `process.argv` intact.
+        // `--` stops node from reading the server flags as its own.
+        args.push("--eval".into());
+        args.push(Self::loader_script(&root));
+        args.push("--".into());
 
         args.push(format!("{server_dir}/index.js"));
         args.push("--stdio".into());


### PR DESCRIPTION
Fixes #99.

## Problem

When `@angular/language-server` is not in the project, node stops before the server starts. Zed shows a `MODULE_NOT_FOUND` stack trace. The trace does not name this extension and does not name the package to install, so the reader cannot act on it. #97 is the same report, answered by hand in the comments.

A filesystem check in the extension is not an option. #95 showed that the Zed worktree snapshot excludes `node_modules`, so the check gives false negatives. The current code documents this and is right to do so.

## Approach

Route the invocation through a small `node --eval` preamble, then pass the entry point and the existing flags after `--`.

The preamble leaves `process.argv` byte for byte identical to a plain `node <entry>` call, so the server parses its own flags unchanged.

```
node --eval <preamble> -- <server>/index.js --stdio --tsProbeLocations ... 
```

It adds two behaviours:

1. **Fallback to node's resolver.** If the literal path does not resolve, try `require.resolve('@angular/language-server', { paths: [root] })`. Node walks up the directory tree, so a workspace that hoists the package to a parent `node_modules` now works with no `angular_language_server_path` setting.
2. **A usable error.** If both fail, print the locations tried, the install command, and the major version rule, then exit 1.

All resolution stays inside node. The extension performs no filesystem access, so #95 cannot regress.

## Before

```text
node:internal/modules/cjs/loader:1503
  throw err;
  ^
Error: Cannot find module '/Users/me/proj/node_modules/@angular/language-server/index.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1500:15)
    ... 7 more frames
  code: 'MODULE_NOT_FOUND',
```

## After

```text
The Angular extension cannot find the @angular/language-server package.

It looked in these locations:
  /Users/me/proj/node_modules/@angular/language-server/index.js
  node module resolution from /Users/me/proj

The extension does not download a language server. Install the package
in your project:

  npm install --save-dev @angular/language-server typescript

The major version of @angular/language-server must be equal to the major
version of Angular in your project.

If the package is in a different location, set the location in your Zed
settings with this option:
  lsp.angular.initialization_options.angular_language_server_path
```

## Testing

Built with `cargo build --release --target wasm32-wasip1`. `cargo fmt --check` is clean.

The shipped preamble was extracted from the built source and driven with a real LSP `initialize` request against `@angular/language-server` 21.1.5 on node v24.16.0:

| Scenario | Result |
| --- | --- |
| Package present at the literal path | Server starts, `initialize` responds with `capabilities` |
| Literal path wrong, package hoisted at the worktree root | Server starts, `initialize` responds with `capabilities` |
| Package genuinely absent | Message above, exit 1, no stack trace |

Scenario 1 confirms no behaviour change on the existing happy path. Scenario 2 is new. `parseCommandLine` in `@angular/language-server` scans argv with `indexOf`, and the preamble preserves argv positions anyway, so flag parsing is unaffected.

## Notes

- The two behaviours are independent. If you want only the diagnostic and not the resolver fallback, I am happy to drop the fallback branch.
- I did not touch `extension.toml` or `Cargo.toml` versions, since releases look like separate commits in this repo. Tell me if you want the bump included here.
